### PR TITLE
Allow multiseries requests

### DIFF
--- a/bls/api.py
+++ b/bls/api.py
@@ -44,7 +44,7 @@ def _get_json_subset(series, startyear, endyear, key):
     }
     if key is not None:
         data['registrationkey'] = key
-    response = requests.post(BASE_URL, data=data).json()
+    response = requests.post(BASE_URL, json=data).json()
     for message in response['message']:
         log.warning(message)
     if response['status'] != 'REQUEST_SUCCEEDED':


### PR DESCRIPTION
Newish to python and git and api requests, so my solution may not be advisable.  I was unable to make a multiseries request, but specifying that the post request was json format fixes the issue.  Code that did not work prior to PR: 

```python
# registration key will need to be specified
jdat = bls.get_series(["SUUR0000SA0", "CUUR0000SA0"], startyear=2011, endyear=2011, key=regkey)
```